### PR TITLE
README: add .nvim suffix to URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Installation Method
     Dein
         Add the following to your .vimrc, and run call dein#install():
 
-    call dein#add('Mitch1000/backpack')
+    call dein#add('Mitch1000/backpack.nvim')
 
     Packer
-        use {'mitch1000/backpack' }
+        use {'mitch1000/backpack.nvim' }
 
     Lazy
         {
-          'mitch1000/backpack',
+          'mitch1000/backpack.nvim',
           config = function ()
             require('backpack').setup()
           end


### PR DESCRIPTION
Fixes the current Lazy snippet not working for me. I can't speak for the other plugin managers, but I assume it's the same issue there?